### PR TITLE
chore: Added the feature to use private NPM registry for downloading package…

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,84 @@
+name: Continuous Integration / Deployment
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      awsAccount:
+        type: choice
+        description: "The AWS account to target for testing/deployment"
+        required: true
+        default: "NON_PCI_DEV_PRIVATE"
+        options:
+          - NON_PCI_DEV_PRIVATE
+          - NON_PCI_DEV
+          - NON_PCI_PROD
+      tag:
+        type: string
+        description: "Repository tag/commit/branch to checkout"
+        required: true
+        default: "main"
+      deployInfra:
+        type: boolean
+        description: "Deploy Infrastructure (optional)"
+        required: true
+        # TODO: MAKE THIS FALSE BY DEFAULT BEFORE MERGING
+        default: true
+
+# Adding the concurrency tag with cancel-in-progress: true stops builds
+#  for a certain group if a new push comes in with that same group.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cicd:
+    runs-on:
+      group: 7920-godaddyconstruc0
+      labels:
+        - 7920-godaddyconstruc0
+        - self-hosted
+
+    steps:
+      # Checkout all branches for diff comparisons
+      - name: Checkout Code
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        with:
+          ref: ${{ github.event.inputs.tag }}
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
+        with:
+          python-version: 3.8
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      # Get the Artifactory NPM token from ASM on CICD account
+      - name: Get Artifactory NPM token from ASM
+        run: |
+          ARTIFACTORY_NPM_TOKEN=$(aws secretsmanager get-secret-value --secret-id /Artifactory/GoDaddyConstructs/RW/NPM/Token --query SecretString --region us-west-2 --output text)
+          echo "::add-mask::$ARTIFACTORY_NPM_TOKEN"
+          echo "ARTIFACTORY_NPM_TOKEN=${ARTIFACTORY_NPM_TOKEN}" >> $GITHUB_ENV
+
+      # Install NPM Dependencies
+      - name: Install NPM Dependencies
+        run: make init-app
+
+      # Build, lint, and test
+      - name: Build application
+        run: make build-app
+
+      # Deploy
+      - name: Deploy Application to NPM
+        if: ${{ github.event_name == 'release' }}
+        run: make publish-app-npm
+        env:
+          ARTIFACTORY_NPM_TOKEN: ${{ env.ARTIFACTORY_NPM_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ init-app: clean
 	npm ci --userconfig=.npmrcCI -f
 
 .PHONY: build-app
-build-app: clean bump-version init-app
+build-app: clean init-app
     # This is the command to build the app which includes linting, testing, and building the app
 	yarn build
 
 .PHONY: bump-version
-bump-version:
+bump-version: build-app
 	echo "Using version: $(VERSION)"
 	yarn bump
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gd-constructs/construct-hub",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gd-constructs/construct-hub",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.84.0-alpha.0",

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.0",
+  "version": "1.0.0",
   "jest": {
     "maxConcurrency": 2,
     "moduleNameMapper": {

--- a/src/__tests__/__snapshots__/construct-hub.test.ts.snap
+++ b/src/__tests__/__snapshots__/construct-hub.test.ts.snap
@@ -1609,7 +1609,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "af095c3c3f6c6e424ac5e9cc1b60e4b0baa89248626958e05f3179de466d4b14.zip",
+          "S3Key": "e52c35d1bd326d982122b0fd30802b2a51cd5f1ba000fdc260206da5b2df460b.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -2086,7 +2086,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b31d25f624fc0dd943123d0b7601b5bf3a3ae063729316a521fd20b34f055638.zip",
+          "S3Key": "f870c4df552827151f00c75b9bec67897620ff53cc53caccc8ace0018731145d.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2314,7 +2314,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3375c27e6f7a2cbe6c503cf6fcd6fbfb42d0879c404b41d8ec72dcfb6f4c3cb.zip",
+          "S3Key": "310e1930ced56ffccacfabb8b9a75921d27506a86c8495c345746123c5850c3c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -2740,7 +2740,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "36d16acc55341c7f701d71a14c665bff56ef2f654b893bd2aa62ebc5beb6b2f2.zip",
+          "S3Key": "4eb73133997fe0beac4a0b0333c591cb0e99d63aa2d1420097ca45ef656321cf.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -3406,7 +3406,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a585c01513d87948bcc2a654a0f9cffe8ffde5df37b150608db1fc3c0ec12a91.zip",
+          "S3Key": "9a2e40c655c83c4f3193464228723ce9a6acd69782ce796434b9be43ad766c22.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -4903,7 +4903,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "589a8b5af4754ef26c563d9c7ca055f2db2acc643a521fba3b72725995ed9542.zip",
+          "S3Key": "f74cf8320697c1b4e1dc5e320c37e28ac5226b265e312079810e52d80e89c449.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5217,7 +5217,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7361ce9ec7424b3bced8044c61ce32e742869eaa32350338311e1240979671a.zip",
+          "S3Key": "67f586981e54b6d8e6aefd211c9a0c85214a73096ebb945eb88c1ba5cd061bb4.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5971,7 +5971,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4151f68eb4abd7231b1de447bccc03b286ba92f57cf1a95c4ba30a0286f3957c.zip",
+          "S3Key": "3f9e4eb5ec00ea3853883fb7bfc0b139dba17f3bf099b36c7cf96e8934ebf6f1.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6126,7 +6126,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2fb9fe7574004cc2caf9c648e047ea45be92b66b6ebfe02a957d51fbc3d17c38.zip",
+          "S3Key": "5d5b38ad2e9096331be39cc427c8b399360730753e954fcf8cf8637c44ca6f2a.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -6909,7 +6909,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -9501,7 +9501,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "40d78a0298a5781841edc17dffa4cfa1f5d4eccc050f977bf7425577a3e8603c.zip",
+          "S3Key": "3266ae3f983de89761bc8717b65683d5145da9dfd462901561f184e8cf3ce880.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -9555,7 +9555,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "57bcdc93a955a6b58af8431567be6b8276fe43eca156a4f1d9fc526257d7a964.zip",
+          "S3Key": "8cf3da826c38716a20f91b2b660a5c2b4f1361bf911df559c31e02f9c07aa22c.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -10260,7 +10260,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "79fa38552f3558119232b05ca95dcfa22d6e4f2c538c1ec38f9a721721f75251.zip",
+          "S3Key": "883a45678308892a240e606ff8d871a604ca665f1cbf8512819e2e480896c665.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -10671,7 +10671,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dc3a45eb434fea853813ecce3f76cb3b3cb0ee2483673a1d2e0762fd970bb2e6.zip",
+          "S3Key": "515b92e3391dad97f5d7a0631a4e7713cce30ec9cb59923bc99b515db89d9b1e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -10878,7 +10878,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b01040d6ba8c7a9d6035c300be5890e7d3930a6487829b42d50df1017cda98e0.zip",
+          "S3Key": "222d936491e5bfc8bb2e9e354bdb75c90839a90ceab55b3d967be5cd4ade33fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -12146,7 +12146,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ec9eb55cfff061c681a10b35398c38753e794c152b868ecb6d3970024d65a8f4.zip",
+          "S3Key": "4de4c71a308b6366f0b987bf8dc0f870948ab365dbf160417da690d492db0e5e.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -14555,7 +14555,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "af095c3c3f6c6e424ac5e9cc1b60e4b0baa89248626958e05f3179de466d4b14.zip",
+          "S3Key": "e52c35d1bd326d982122b0fd30802b2a51cd5f1ba000fdc260206da5b2df460b.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -15032,7 +15032,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b31d25f624fc0dd943123d0b7601b5bf3a3ae063729316a521fd20b34f055638.zip",
+          "S3Key": "f870c4df552827151f00c75b9bec67897620ff53cc53caccc8ace0018731145d.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -15260,7 +15260,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3375c27e6f7a2cbe6c503cf6fcd6fbfb42d0879c404b41d8ec72dcfb6f4c3cb.zip",
+          "S3Key": "310e1930ced56ffccacfabb8b9a75921d27506a86c8495c345746123c5850c3c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -15704,7 +15704,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "36d16acc55341c7f701d71a14c665bff56ef2f654b893bd2aa62ebc5beb6b2f2.zip",
+          "S3Key": "4eb73133997fe0beac4a0b0333c591cb0e99d63aa2d1420097ca45ef656321cf.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -16450,7 +16450,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a585c01513d87948bcc2a654a0f9cffe8ffde5df37b150608db1fc3c0ec12a91.zip",
+          "S3Key": "9a2e40c655c83c4f3193464228723ce9a6acd69782ce796434b9be43ad766c22.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -17947,7 +17947,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "589a8b5af4754ef26c563d9c7ca055f2db2acc643a521fba3b72725995ed9542.zip",
+          "S3Key": "f74cf8320697c1b4e1dc5e320c37e28ac5226b265e312079810e52d80e89c449.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -18261,7 +18261,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7361ce9ec7424b3bced8044c61ce32e742869eaa32350338311e1240979671a.zip",
+          "S3Key": "67f586981e54b6d8e6aefd211c9a0c85214a73096ebb945eb88c1ba5cd061bb4.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -19015,7 +19015,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4151f68eb4abd7231b1de447bccc03b286ba92f57cf1a95c4ba30a0286f3957c.zip",
+          "S3Key": "3f9e4eb5ec00ea3853883fb7bfc0b139dba17f3bf099b36c7cf96e8934ebf6f1.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -19170,7 +19170,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2fb9fe7574004cc2caf9c648e047ea45be92b66b6ebfe02a957d51fbc3d17c38.zip",
+          "S3Key": "5d5b38ad2e9096331be39cc427c8b399360730753e954fcf8cf8637c44ca6f2a.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -19980,7 +19980,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -22618,7 +22618,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "40d78a0298a5781841edc17dffa4cfa1f5d4eccc050f977bf7425577a3e8603c.zip",
+          "S3Key": "3266ae3f983de89761bc8717b65683d5145da9dfd462901561f184e8cf3ce880.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -22672,7 +22672,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "57bcdc93a955a6b58af8431567be6b8276fe43eca156a4f1d9fc526257d7a964.zip",
+          "S3Key": "8cf3da826c38716a20f91b2b660a5c2b4f1361bf911df559c31e02f9c07aa22c.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -23377,7 +23377,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "79fa38552f3558119232b05ca95dcfa22d6e4f2c538c1ec38f9a721721f75251.zip",
+          "S3Key": "883a45678308892a240e606ff8d871a604ca665f1cbf8512819e2e480896c665.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -23788,7 +23788,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dc3a45eb434fea853813ecce3f76cb3b3cb0ee2483673a1d2e0762fd970bb2e6.zip",
+          "S3Key": "515b92e3391dad97f5d7a0631a4e7713cce30ec9cb59923bc99b515db89d9b1e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -23995,7 +23995,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b01040d6ba8c7a9d6035c300be5890e7d3930a6487829b42d50df1017cda98e0.zip",
+          "S3Key": "222d936491e5bfc8bb2e9e354bdb75c90839a90ceab55b3d967be5cd4ade33fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -25263,7 +25263,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ec9eb55cfff061c681a10b35398c38753e794c152b868ecb6d3970024d65a8f4.zip",
+          "S3Key": "4de4c71a308b6366f0b987bf8dc0f870948ab365dbf160417da690d492db0e5e.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -27407,7 +27407,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "af095c3c3f6c6e424ac5e9cc1b60e4b0baa89248626958e05f3179de466d4b14.zip",
+          "S3Key": "e52c35d1bd326d982122b0fd30802b2a51cd5f1ba000fdc260206da5b2df460b.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -27884,7 +27884,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b31d25f624fc0dd943123d0b7601b5bf3a3ae063729316a521fd20b34f055638.zip",
+          "S3Key": "f870c4df552827151f00c75b9bec67897620ff53cc53caccc8ace0018731145d.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -28112,7 +28112,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3375c27e6f7a2cbe6c503cf6fcd6fbfb42d0879c404b41d8ec72dcfb6f4c3cb.zip",
+          "S3Key": "310e1930ced56ffccacfabb8b9a75921d27506a86c8495c345746123c5850c3c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -28538,7 +28538,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "36d16acc55341c7f701d71a14c665bff56ef2f654b893bd2aa62ebc5beb6b2f2.zip",
+          "S3Key": "4eb73133997fe0beac4a0b0333c591cb0e99d63aa2d1420097ca45ef656321cf.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -29204,7 +29204,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a585c01513d87948bcc2a654a0f9cffe8ffde5df37b150608db1fc3c0ec12a91.zip",
+          "S3Key": "9a2e40c655c83c4f3193464228723ce9a6acd69782ce796434b9be43ad766c22.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -30701,7 +30701,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "589a8b5af4754ef26c563d9c7ca055f2db2acc643a521fba3b72725995ed9542.zip",
+          "S3Key": "f74cf8320697c1b4e1dc5e320c37e28ac5226b265e312079810e52d80e89c449.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -31015,7 +31015,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7361ce9ec7424b3bced8044c61ce32e742869eaa32350338311e1240979671a.zip",
+          "S3Key": "67f586981e54b6d8e6aefd211c9a0c85214a73096ebb945eb88c1ba5cd061bb4.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -31769,7 +31769,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4151f68eb4abd7231b1de447bccc03b286ba92f57cf1a95c4ba30a0286f3957c.zip",
+          "S3Key": "3f9e4eb5ec00ea3853883fb7bfc0b139dba17f3bf099b36c7cf96e8934ebf6f1.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -31924,7 +31924,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2fb9fe7574004cc2caf9c648e047ea45be92b66b6ebfe02a957d51fbc3d17c38.zip",
+          "S3Key": "5d5b38ad2e9096331be39cc427c8b399360730753e954fcf8cf8637c44ca6f2a.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -32707,7 +32707,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -35299,7 +35299,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "40d78a0298a5781841edc17dffa4cfa1f5d4eccc050f977bf7425577a3e8603c.zip",
+          "S3Key": "3266ae3f983de89761bc8717b65683d5145da9dfd462901561f184e8cf3ce880.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -35353,7 +35353,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "57bcdc93a955a6b58af8431567be6b8276fe43eca156a4f1d9fc526257d7a964.zip",
+          "S3Key": "8cf3da826c38716a20f91b2b660a5c2b4f1361bf911df559c31e02f9c07aa22c.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -36058,7 +36058,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "79fa38552f3558119232b05ca95dcfa22d6e4f2c538c1ec38f9a721721f75251.zip",
+          "S3Key": "883a45678308892a240e606ff8d871a604ca665f1cbf8512819e2e480896c665.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -36469,7 +36469,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dc3a45eb434fea853813ecce3f76cb3b3cb0ee2483673a1d2e0762fd970bb2e6.zip",
+          "S3Key": "515b92e3391dad97f5d7a0631a4e7713cce30ec9cb59923bc99b515db89d9b1e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -36676,7 +36676,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b01040d6ba8c7a9d6035c300be5890e7d3930a6487829b42d50df1017cda98e0.zip",
+          "S3Key": "222d936491e5bfc8bb2e9e354bdb75c90839a90ceab55b3d967be5cd4ade33fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -37944,7 +37944,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ec9eb55cfff061c681a10b35398c38753e794c152b868ecb6d3970024d65a8f4.zip",
+          "S3Key": "4de4c71a308b6366f0b987bf8dc0f870948ab365dbf160417da690d492db0e5e.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -40236,7 +40236,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "af095c3c3f6c6e424ac5e9cc1b60e4b0baa89248626958e05f3179de466d4b14.zip",
+          "S3Key": "e52c35d1bd326d982122b0fd30802b2a51cd5f1ba000fdc260206da5b2df460b.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -40713,7 +40713,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b31d25f624fc0dd943123d0b7601b5bf3a3ae063729316a521fd20b34f055638.zip",
+          "S3Key": "f870c4df552827151f00c75b9bec67897620ff53cc53caccc8ace0018731145d.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -40928,7 +40928,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3375c27e6f7a2cbe6c503cf6fcd6fbfb42d0879c404b41d8ec72dcfb6f4c3cb.zip",
+          "S3Key": "310e1930ced56ffccacfabb8b9a75921d27506a86c8495c345746123c5850c3c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -41354,7 +41354,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "36d16acc55341c7f701d71a14c665bff56ef2f654b893bd2aa62ebc5beb6b2f2.zip",
+          "S3Key": "4eb73133997fe0beac4a0b0333c591cb0e99d63aa2d1420097ca45ef656321cf.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -42020,7 +42020,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a585c01513d87948bcc2a654a0f9cffe8ffde5df37b150608db1fc3c0ec12a91.zip",
+          "S3Key": "9a2e40c655c83c4f3193464228723ce9a6acd69782ce796434b9be43ad766c22.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -43539,7 +43539,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "589a8b5af4754ef26c563d9c7ca055f2db2acc643a521fba3b72725995ed9542.zip",
+          "S3Key": "f74cf8320697c1b4e1dc5e320c37e28ac5226b265e312079810e52d80e89c449.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -43853,7 +43853,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7361ce9ec7424b3bced8044c61ce32e742869eaa32350338311e1240979671a.zip",
+          "S3Key": "67f586981e54b6d8e6aefd211c9a0c85214a73096ebb945eb88c1ba5cd061bb4.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -44607,7 +44607,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4151f68eb4abd7231b1de447bccc03b286ba92f57cf1a95c4ba30a0286f3957c.zip",
+          "S3Key": "3f9e4eb5ec00ea3853883fb7bfc0b139dba17f3bf099b36c7cf96e8934ebf6f1.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -44762,7 +44762,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2fb9fe7574004cc2caf9c648e047ea45be92b66b6ebfe02a957d51fbc3d17c38.zip",
+          "S3Key": "5d5b38ad2e9096331be39cc427c8b399360730753e954fcf8cf8637c44ca6f2a.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -45545,7 +45545,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -48137,7 +48137,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "40d78a0298a5781841edc17dffa4cfa1f5d4eccc050f977bf7425577a3e8603c.zip",
+          "S3Key": "3266ae3f983de89761bc8717b65683d5145da9dfd462901561f184e8cf3ce880.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -48191,7 +48191,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "57bcdc93a955a6b58af8431567be6b8276fe43eca156a4f1d9fc526257d7a964.zip",
+          "S3Key": "8cf3da826c38716a20f91b2b660a5c2b4f1361bf911df559c31e02f9c07aa22c.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -48883,7 +48883,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "79fa38552f3558119232b05ca95dcfa22d6e4f2c538c1ec38f9a721721f75251.zip",
+          "S3Key": "883a45678308892a240e606ff8d871a604ca665f1cbf8512819e2e480896c665.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -49294,7 +49294,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dc3a45eb434fea853813ecce3f76cb3b3cb0ee2483673a1d2e0762fd970bb2e6.zip",
+          "S3Key": "515b92e3391dad97f5d7a0631a4e7713cce30ec9cb59923bc99b515db89d9b1e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -49501,7 +49501,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b01040d6ba8c7a9d6035c300be5890e7d3930a6487829b42d50df1017cda98e0.zip",
+          "S3Key": "222d936491e5bfc8bb2e9e354bdb75c90839a90ceab55b3d967be5cd4ade33fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -51019,7 +51019,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ec9eb55cfff061c681a10b35398c38753e794c152b868ecb6d3970024d65a8f4.zip",
+          "S3Key": "4de4c71a308b6366f0b987bf8dc0f870948ab365dbf160417da690d492db0e5e.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {
@@ -53248,7 +53248,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "af095c3c3f6c6e424ac5e9cc1b60e4b0baa89248626958e05f3179de466d4b14.zip",
+          "S3Key": "e52c35d1bd326d982122b0fd30802b2a51cd5f1ba000fdc260206da5b2df460b.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -53725,7 +53725,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b31d25f624fc0dd943123d0b7601b5bf3a3ae063729316a521fd20b34f055638.zip",
+          "S3Key": "f870c4df552827151f00c75b9bec67897620ff53cc53caccc8ace0018731145d.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -53953,7 +53953,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3375c27e6f7a2cbe6c503cf6fcd6fbfb42d0879c404b41d8ec72dcfb6f4c3cb.zip",
+          "S3Key": "310e1930ced56ffccacfabb8b9a75921d27506a86c8495c345746123c5850c3c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -54379,7 +54379,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "36d16acc55341c7f701d71a14c665bff56ef2f654b893bd2aa62ebc5beb6b2f2.zip",
+          "S3Key": "4eb73133997fe0beac4a0b0333c591cb0e99d63aa2d1420097ca45ef656321cf.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -55171,7 +55171,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a585c01513d87948bcc2a654a0f9cffe8ffde5df37b150608db1fc3c0ec12a91.zip",
+          "S3Key": "9a2e40c655c83c4f3193464228723ce9a6acd69782ce796434b9be43ad766c22.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -56697,7 +56697,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "589a8b5af4754ef26c563d9c7ca055f2db2acc643a521fba3b72725995ed9542.zip",
+          "S3Key": "f74cf8320697c1b4e1dc5e320c37e28ac5226b265e312079810e52d80e89c449.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -57011,7 +57011,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7361ce9ec7424b3bced8044c61ce32e742869eaa32350338311e1240979671a.zip",
+          "S3Key": "67f586981e54b6d8e6aefd211c9a0c85214a73096ebb945eb88c1ba5cd061bb4.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -57358,7 +57358,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4151f68eb4abd7231b1de447bccc03b286ba92f57cf1a95c4ba30a0286f3957c.zip",
+          "S3Key": "3f9e4eb5ec00ea3853883fb7bfc0b139dba17f3bf099b36c7cf96e8934ebf6f1.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -57513,7 +57513,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2fb9fe7574004cc2caf9c648e047ea45be92b66b6ebfe02a957d51fbc3d17c38.zip",
+          "S3Key": "5d5b38ad2e9096331be39cc427c8b399360730753e954fcf8cf8637c44ca6f2a.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -58302,7 +58302,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -60956,7 +60956,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "40d78a0298a5781841edc17dffa4cfa1f5d4eccc050f977bf7425577a3e8603c.zip",
+          "S3Key": "3266ae3f983de89761bc8717b65683d5145da9dfd462901561f184e8cf3ce880.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -61010,7 +61010,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "57bcdc93a955a6b58af8431567be6b8276fe43eca156a4f1d9fc526257d7a964.zip",
+          "S3Key": "8cf3da826c38716a20f91b2b660a5c2b4f1361bf911df559c31e02f9c07aa22c.zip",
         },
         "Description": "[Test/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -61715,7 +61715,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "79fa38552f3558119232b05ca95dcfa22d6e4f2c538c1ec38f9a721721f75251.zip",
+          "S3Key": "883a45678308892a240e606ff8d871a604ca665f1cbf8512819e2e480896c665.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -62126,7 +62126,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dc3a45eb434fea853813ecce3f76cb3b3cb0ee2483673a1d2e0762fd970bb2e6.zip",
+          "S3Key": "515b92e3391dad97f5d7a0631a4e7713cce30ec9cb59923bc99b515db89d9b1e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -65193,7 +65193,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b01040d6ba8c7a9d6035c300be5890e7d3930a6487829b42d50df1017cda98e0.zip",
+          "S3Key": "222d936491e5bfc8bb2e9e354bdb75c90839a90ceab55b3d967be5cd4ade33fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -66994,7 +66994,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ec9eb55cfff061c681a10b35398c38753e794c152b868ecb6d3970024d65a8f4.zip",
+          "S3Key": "4de4c71a308b6366f0b987bf8dc0f870948ab365dbf160417da690d492db0e5e.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {

--- a/src/__tests__/backend/deny-list/__snapshots__/deny-list.test.ts.snap
+++ b/src/__tests__/backend/deny-list/__snapshots__/deny-list.test.ts.snap
@@ -1044,7 +1044,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "af095c3c3f6c6e424ac5e9cc1b60e4b0baa89248626958e05f3179de466d4b14.zip",
+          "S3Key": "e52c35d1bd326d982122b0fd30802b2a51cd5f1ba000fdc260206da5b2df460b.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {

--- a/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/backend/transliterator/__snapshots__/index.test.ts.snap
@@ -229,7 +229,7 @@ exports[`CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -2544,7 +2544,7 @@ exports[`VPC Endpoints 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -5021,7 +5021,7 @@ exports[`VPC Endpoints and CodeArtifact repository 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -7332,7 +7332,7 @@ exports[`basic use 1`] = `
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
+++ b/src/__tests__/devapp/__snapshots__/snapshot.test.ts.snap
@@ -2073,7 +2073,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "af095c3c3f6c6e424ac5e9cc1b60e4b0baa89248626958e05f3179de466d4b14.zip",
+          "S3Key": "e52c35d1bd326d982122b0fd30802b2a51cd5f1ba000fdc260206da5b2df460b.zip",
         },
         "Description": "backend/deny-list/prune-handler.lambda.ts",
         "Environment": {
@@ -2547,7 +2547,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b31d25f624fc0dd943123d0b7601b5bf3a3ae063729316a521fd20b34f055638.zip",
+          "S3Key": "f870c4df552827151f00c75b9bec67897620ff53cc53caccc8ace0018731145d.zip",
         },
         "Description": "Release note RSS feed updater",
         "Environment": {
@@ -2777,7 +2777,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f3375c27e6f7a2cbe6c503cf6fcd6fbfb42d0879c404b41d8ec72dcfb6f4c3cb.zip",
+          "S3Key": "310e1930ced56ffccacfabb8b9a75921d27506a86c8495c345746123c5850c3c.zip",
         },
         "Description": "[ConstructHub/Ingestion] Ingests new package versions into the Construct Hub",
         "Environment": {
@@ -3221,7 +3221,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "36d16acc55341c7f701d71a14c665bff56ef2f654b893bd2aa62ebc5beb6b2f2.zip",
+          "S3Key": "4eb73133997fe0beac4a0b0333c591cb0e99d63aa2d1420097ca45ef656321cf.zip",
         },
         "Description": "[ConstructHub/Ingestion/ReIngest] The function used to reprocess packages through ingestion",
         "Environment": {
@@ -3980,7 +3980,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "a585c01513d87948bcc2a654a0f9cffe8ffde5df37b150608db1fc3c0ec12a91.zip",
+          "S3Key": "9a2e40c655c83c4f3193464228723ce9a6acd69782ce796434b9be43ad766c22.zip",
         },
         "Description": "[ConstructHub/Inventory] A canary that periodically inspects the list of indexed packages",
         "Environment": {
@@ -5520,7 +5520,7 @@ Direct link to function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "589a8b5af4754ef26c563d9c7ca055f2db2acc643a521fba3b72725995ed9542.zip",
+          "S3Key": "f74cf8320697c1b4e1dc5e320c37e28ac5226b265e312079810e52d80e89c449.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -5831,7 +5831,7 @@ RUNBOOK: https://github.com/cdklabs/construct-hub/blob/main/docs/operator-runboo
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "e7361ce9ec7424b3bced8044c61ce32e742869eaa32350338311e1240979671a.zip",
+          "S3Key": "67f586981e54b6d8e6aefd211c9a0c85214a73096ebb945eb88c1ba5cd061bb4.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -6191,7 +6191,7 @@ Warning: State Machines executions that sent messages to the DLQ will not show a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4151f68eb4abd7231b1de447bccc03b286ba92f57cf1a95c4ba30a0286f3957c.zip",
+          "S3Key": "3f9e4eb5ec00ea3853883fb7bfc0b139dba17f3bf099b36c7cf96e8934ebf6f1.zip",
         },
         "Description": "[ConstructHub/Orchestration/NeedsCatalogUpdate] Determines whether a package version requires a catalog update",
         "Environment": {
@@ -6343,7 +6343,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "2fb9fe7574004cc2caf9c648e047ea45be92b66b6ebfe02a957d51fbc3d17c38.zip",
+          "S3Key": "5d5b38ad2e9096331be39cc427c8b399360730753e954fcf8cf8637c44ca6f2a.zip",
         },
         "Description": "[ConstructHub/Redrive] Manually redrives all messages from the backend dead letter queue",
         "Environment": {
@@ -7183,7 +7183,7 @@ Warning: messages that resulted in a failed exectuion will NOT be in the DLQ!",
             ],
             "Essential": true,
             "Image": {
-              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0168e3e70677592ed823427014e308680a8a9f5b8c10a056aabab94b788aa2e7",
+              "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:29ee4f713e884f1c7372d94bf6ded53fd739b1da1c90953ba7ed19afb5fcbd43",
             },
             "LogConfiguration": {
               "LogDriver": "awslogs",
@@ -10791,7 +10791,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "40d78a0298a5781841edc17dffa4cfa1f5d4eccc050f977bf7425577a3e8603c.zip",
+          "S3Key": "3266ae3f983de89761bc8717b65683d5145da9dfd462901561f184e8cf3ce880.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs] Periodically query npmjs.com index for new packages",
         "Environment": {
@@ -10845,7 +10845,7 @@ Direct link to the function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "57bcdc93a955a6b58af8431567be6b8276fe43eca156a4f1d9fc526257d7a964.zip",
+          "S3Key": "8cf3da826c38716a20f91b2b660a5c2b4f1361bf911df559c31e02f9c07aa22c.zip",
         },
         "Description": "[dev/ConstructHub/Sources/NpmJs/PackageCanary] Monitors construct-hub-probe versions availability",
         "Environment": {
@@ -11544,7 +11544,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "79fa38552f3558119232b05ca95dcfa22d6e4f2c538c1ec38f9a721721f75251.zip",
+          "S3Key": "883a45678308892a240e606ff8d871a604ca665f1cbf8512819e2e480896c665.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -11955,7 +11955,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dc3a45eb434fea853813ecce3f76cb3b3cb0ee2483673a1d2e0762fd970bb2e6.zip",
+          "S3Key": "515b92e3391dad97f5d7a0631a4e7713cce30ec9cb59923bc99b515db89d9b1e.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -15153,7 +15153,7 @@ Direct link to Lambda function: /lambda/home#/functions/",
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b01040d6ba8c7a9d6035c300be5890e7d3930a6487829b42d50df1017cda98e0.zip",
+          "S3Key": "222d936491e5bfc8bb2e9e354bdb75c90839a90ceab55b3d967be5cd4ade33fe.zip",
         },
         "Description": {
           "Fn::Join": [
@@ -16421,7 +16421,7 @@ function handler(event) {
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ec9eb55cfff061c681a10b35398c38753e794c152b868ecb6d3970024d65a8f4.zip",
+          "S3Key": "4de4c71a308b6366f0b987bf8dc0f870948ab365dbf160417da690d492db0e5e.zip",
         },
         "Description": "[ConstructHub/MissingDocumentationWidget] Is a custom CloudWatch widget handler",
         "Environment": {

--- a/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
+++ b/src/__tests__/package-sources/__snapshots__/code-artifact.test.ts.snap
@@ -243,7 +243,7 @@ exports[`default configuration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "398c25dc4931fc81aa0bc34c66473ae8de45d4e025f6deea551d10627415d9bb.zip",
+          "S3Key": "e2ee8911adfad30ebf1e741fb4561eb329e68aced53d567a6a64a298faedbb8b.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {
@@ -727,7 +727,7 @@ exports[`user-provided staging bucket 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "398c25dc4931fc81aa0bc34c66473ae8de45d4e025f6deea551d10627415d9bb.zip",
+          "S3Key": "e2ee8911adfad30ebf1e741fb4561eb329e68aced53d567a6a64a298faedbb8b.zip",
         },
         "DeadLetterConfig": {
           "TargetArn": {

--- a/src/backend/ingestion/ingestion.lambda.ts
+++ b/src/backend/ingestion/ingestion.lambda.ts
@@ -268,6 +268,9 @@ export const handler = metricScope(
         licenseText: licenseText?.toString('utf-8'),
         packageLinks,
         packageTags,
+        links: payload.metadata?.npmPackageUrl
+          ? { npm: payload.metadata.npmPackageUrl }
+          : undefined,
       };
 
       const { assemblyKey, metadataKey, packageKey } = constants.getObjectKeys(

--- a/src/backend/orchestration/index.ts
+++ b/src/backend/orchestration/index.ts
@@ -106,6 +106,11 @@ export interface OrchestrationProps {
   readonly codeArtifact?: Repository;
 
   /**
+   * The private NPM registry secret ARN which contains the Artifactory URL and token.
+   */
+  readonly artifactorySecretArn?: string;
+
+  /**
    * The monitoring handler to register alarms with.
    */
   readonly monitoring: Monitoring;

--- a/src/backend/shared/aws.lambda-shared.ts
+++ b/src/backend/shared/aws.lambda-shared.ts
@@ -12,12 +12,20 @@ let _sqs: AWS.SQS | undefined;
 let _sfn: AWS.StepFunctions | undefined;
 let _lambda: AWS.Lambda | undefined;
 let _codeArtifact: AWS.CodeArtifact | undefined;
+let _secretsManager: AWS.SecretsManager | undefined;
 
 export function ecs(): AWS.ECS {
   if (_ecs == null) {
     _ecs = new AWS.ECS();
   }
   return _ecs;
+}
+
+export function secretsManager(): AWS.SecretsManager {
+  if (_secretsManager == null) {
+    _secretsManager = new AWS.SecretsManager();
+  }
+  return _secretsManager;
 }
 
 export function s3(): AWS.S3 {

--- a/src/backend/transliterator/index.ts
+++ b/src/backend/transliterator/index.ts
@@ -47,6 +47,11 @@ export interface TransliteratorProps {
   readonly codeArtifact?: Repository;
 
   /**
+   * The private NPM registry secret ARN which contains the Artifactory URL and token.
+   */
+  readonly artifactorySecretArn?: string;
+
+  /**
    * The monitoring handler to register alarms with.
    */
   readonly monitoring: Monitoring;
@@ -153,6 +158,11 @@ export class Transliterator extends Construct {
         props.codeArtifact.repositoryDomainOwner;
       environment.CODE_ARTIFACT_REPOSITORY_ENDPOINT =
         props.codeArtifact.repositoryNpmEndpoint;
+    }
+
+    // Set up the private NPM registry environment variables.
+    if (props.artifactorySecretArn) {
+      environment.ARTIFACTORY_SECRET_ARN = props.artifactorySecretArn;
     }
 
     this.logGroup = new LogGroup(this, 'LogGroup', {

--- a/src/backend/transliterator/util.ts
+++ b/src/backend/transliterator/util.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
 import * as internal from 'stream';
+import * as aws from '../shared/aws.lambda-shared';
+import { shellOut } from '../shared/shell-out.lambda-shared';
 
 export async function writeFile(
   filePath: string,
@@ -14,4 +16,65 @@ export async function writeFile(
       ok();
     });
   });
+}
+
+/**
+ * Artifactory Secret containing the Artifactory URL and token.
+ */
+interface ArtifactorySecret {
+  /**
+   * The URL of the Artifactory instance.
+   */
+  url: string;
+
+  /**
+   * The token to authenticate with the Artifactory instance.
+   */
+  token: string;
+}
+
+/**
+ * Logs into the provided private NPM registry, and makes it the default NPM
+ * registry for this environment.
+ */
+export async function setNpmConfig(secretArn: string) {
+  // Get the Artifactory secret from AWS Secrets Manager
+  const artifactorySecret = await getArtifactorySecret(secretArn);
+  const registryUrl = `${artifactorySecret.url}/artifactory/api/npm/node-virt/`;
+
+  // Remove the protocol part of the endpoint URL, keeping the rest intact.
+  const protoRelativeEndpoint = registryUrl.replace(/^[^:]+:/, '');
+  await shellOut('npm', 'config', 'set', `registry=${registryUrl}`);
+  await shellOut(
+    'npm',
+    'config',
+    'set',
+    `${protoRelativeEndpoint}:_authToken=${artifactorySecret.token}`
+  );
+  await shellOut(
+    'npm',
+    'config',
+    'set',
+    `${protoRelativeEndpoint}:always-auth=true`
+  );
+}
+
+/**
+ * Gets the Artifactory secret from AWS Secrets Manager.
+ * @param secretArn
+ */
+async function getArtifactorySecret(
+  secretArn: string
+): Promise<ArtifactorySecret> {
+  try {
+    // Call the AWS Secrets Manager API to get the secret values
+    const data = await aws
+      .secretsManager()
+      .getSecretValue({ SecretId: secretArn })
+      .promise();
+
+    return JSON.parse(data.SecretString || '');
+  } catch (error) {
+    throw error;
+  }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a PR to this repository.  To ensure that we get quality PRs which are easy to review, please fill out the template to the best of your ability.  Add additional information if you feel the template does not give a complete picture of the work.

Any line with an 🚨 on it should be completely replaced with your own words, removing the 🚨 and example text.  If you feel that one of these lines is unnecessary, please write N/A instead.

Please structure the title of your PR formally as:
[FEATURE] - Description of your feature
[UPDATE] - Description of the updates you've made
[BUG] - Description of your bug fix
[DOCS] - Description of your doc changes
[MAINT] - Description of the maintenance to the repo
-->

## What's Changed

<!--
Please include a one or two line summary of what's contained in the PR.  You'll get the chance to fill in more detail later.
-->

This PR adds the following updates:
- Main Changes
   - Added logic in `src/backend/ingestion/ingestion.lambda.ts` to pass `npmPackageUrl` to `metadata.json`, this will allow the frontend to display the link to `GDArtifactory` package URL.
   - Added logic to set private npm config inside documentation transliteration ECS task, capturing URL and token from users via the Orchestration construct. This will allow it to download packages from our GD Artifactory.

### This change contains:

- [x] New Features
- [ ] Improvements
- [ ] Bug Fixes
- [ ] Documentation changes
- [ ] Repository maintenance

### Within this PR I have:

- [ ] Updated relevant documentation
- [ ] Updated tests
- [x] Adequately described the PR in this document

### Scope of Change

<!--
We follow [semver](https://semver.org) for versioning.  Please familiarize yourself with this system and consider the scope of your changes.  Then check the corresponding box below.
-->

- [x] Breaking Change (Major release bump)
- [ ] New, backwards compatible feature (Minor release bump)
- [ ] Backwards compatible bugfix, update, or change, which does not impact the public api (Patch release bump)
- [ ] No version change required (doc update, repo maintenance, etc...)

#### Breaking Changes

<!--
If there are any breaking changes please describe them in detail here, otherwise just put N/A
-->

N/A

### Details

<!--
Please provide details about what was changed.  Feel free to be descriptive here and dig in.
-->

There is no direct way to make construct hub download packages from our private NPM (`GD Artifactory`) during documentation transliteration done in an ECS task in Orchestration Step , so we decided to fork the [AWS ConstructHub Repo](https://github.com/cdklabs/construct-hub) and add the missing changes to get it to download packages from private NPM registry (if URL and token provided). 



### Motivation

<!--
It is critically important for a present and future review of this work to understand driving motivation.
-->

These changes will allow our [CDK ConstructHub](https://github.com/gdcorp-appservices/cdk-construct-hub/) to index packages with private dependencies. Without this change, the documentation transliteration part fails as it is unable to reach our private NPM registry.

## Related Issues/Stories/PRs/etc...

<!--
GitHub does a great job of auto resolving/closing related issues if you use syntax like:
  resolves #123
If this resolves multiple issues, please add a full "resolves" line for each
You can also link to JIRA stories if that's helpful.
-->

resolves: [CPSLN-6914](https://godaddy-corp.atlassian.net/browse/CPSLN-6914)

## Notes for Reviewers

<!--
Please provide any other comments/notes/etc... that may be valuable to a reviewer.
Try to make their life as easy as possible.  Assume they need context to give you a quality review.

If you think it's helpful, please add comments to your code to call out the items discussed here.
-->

N/A


[CPSLN-6914]: https://godaddy-corp.atlassian.net/browse/CPSLN-6914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ